### PR TITLE
Gracefully handle ^D and treat it like ^C.

### DIFF
--- a/cvss/cvss_calculator.py
+++ b/cvss/cvss_calculator.py
@@ -66,7 +66,7 @@ def main():
                     print(scores[i])
             print('Cleaned vector:       ', cvss_vector.clean_vector())
             print('Red Hat vector:       ', cvss_vector.rh_vector())
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, EOFError):
         print()
 
 


### PR DESCRIPTION
Previously EOF was not handled and pressing ^D leads to an EOFError exception
(for Unix muscle memory is usually handy to just exit via a ^D), e.g.:

    % cvss_calculator
    Interactive CVSS3 calculator
    
    Attack Vector: Network | Adjacent | Local | Physical
    Attack Vector: N/A/L/P ^D
    Traceback (most recent call last):
      File "/usr/pkg/bin/cvss_calculator-2.7", line 11, in <module>
        load_entry_point('cvss==1.7', 'console_scripts', 'cvss_calculator')()
      File "/usr/pkg/lib/python2.7/site-packages/cvss/cvss_calculator.py", line 42, in main
        vector_string = ask_interactively(version, args.all, args.no_colors)
      File "/usr/pkg/lib/python2.7/site-packages/cvss/interactive.py", line 98, in ask_interactively
        input_value = string_input().upper()
    EOFError

Handle EOFError exception in the same way of KeyboardInterrupt.