### PR TITLE
Permits to run the tests also if no `cvss' module is installed

### DIFF
--- a/tests/test_cvss2.py
+++ b/tests/test_cvss2.py
@@ -2,6 +2,8 @@ from os import path
 import sys
 import unittest
 
+sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
+
 from cvss import CVSS2
 from cvss.exceptions import CVSS2MalformedError, CVSS2MandatoryError, CVSS2RHScoreDoesNotMatch, \
     CVSS2RHMalformedError

--- a/tests/test_cvss3.py
+++ b/tests/test_cvss3.py
@@ -2,6 +2,8 @@ from os import path
 import sys
 import unittest
 
+sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
+
 from cvss import CVSS3
 from cvss.exceptions import CVSS3MalformedError, CVSS3MandatoryError, CVSS3RHScoreDoesNotMatch, \
     CVSS3RHMalformedError


### PR DESCRIPTION
Pick up `cvss' module from the parent directory in order to properly
run the tests without having the cvss module installed.

Logic inspired by youtube-dl.