### PR TITLE
CVSS JSON schema repr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test
-      run: cd tests && bash run_tests.sh
+      run: pip install jsonschema && cd tests && bash run_tests.sh
 
     strategy:
       matrix:

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -14,7 +14,8 @@ from __future__ import unicode_literals
 import copy
 from decimal import Decimal as D, ROUND_CEILING
 
-from .constants3 import METRICS_ABBREVIATIONS, METRICS_MANDATORY, METRICS_VALUES
+from .constants3 import METRICS_ABBREVIATIONS, METRICS_MANDATORY, METRICS_VALUES, \
+    METRICS_VALUE_NAMES
 from .exceptions import CVSS3MalformedError, CVSS3MandatoryError, CVSS3RHMalformedError, \
     CVSS3RHScoreDoesNotMatch
 
@@ -193,6 +194,14 @@ class CVSS3(object):
             result = {'X': None, 'N': D('0.85'), 'L': D('0.68'), 'H': D('0.50')}[string_value]
         else:
             result = METRICS_VALUES[abbreviation][string_value]
+        return result
+
+    def get_value_description(self, abbreviation):
+        """
+        Gets textual description of specific metric specified by its abbreviation.
+        """
+        string_value = self.metrics.get(abbreviation, 'X')
+        result = METRICS_VALUE_NAMES[abbreviation][string_value]
         return result
 
     def compute_isc_base(self):
@@ -399,3 +408,65 @@ class CVSS3(object):
 
     def __hash__(self):
         return hash(self.clean_vector())
+
+    def as_json(self):
+        """
+        Returns a dictionary formatted with attribute names and values defined by the official
+        CVSS JSON schema:
+
+        CVSS v3.0: https://www.first.org/cvss/cvss-v3.0.json?20170531
+        CVSS v3.1: https://www.first.org/cvss/cvss-v3.1.json?20190610
+
+        Serialize a `cvss` instance to JSON with:
+
+        json.dumps(cvss.as_json())
+
+        Returns:
+            (dict): JSON schema-compatible CVSS representation
+        """
+        def us(text):
+            # If this is the (modified) attack vector description, convert it from "adjacent" to
+            # "adjacent network" as defined by the schema.
+            if text == 'Adjacent':
+                return 'ADJACENT_NETWORK'
+            # Uppercase and convert to snake case
+            return text.upper().replace('-', '_').replace(' ', '_')
+
+        base_severity, temporal_severity, environmental_everity = self.severities()
+        return {
+            # Meta
+            'version': '3.' + str(self.minor_version),
+            # Vector
+            'vectorString': self.vector,
+            # Metrics
+            'attackVector': us(self.get_value_description('AV')),
+            'attackComplexity': us(self.get_value_description('AC')),
+            'privilegesRequired': us(self.get_value_description('PR')),
+            'userInteraction': us(self.get_value_description('UI')),
+            'scope': us(self.get_value_description('S')),
+            'confidentialityImpact': us(self.get_value_description('C')),
+            'integrityImpact': us(self.get_value_description('I')),
+            'availabilityImpact': us(self.get_value_description('A')),
+            'exploitCodeMaturity': us(self.get_value_description('E')),
+            'remediationLevel': us(self.get_value_description('RL')),
+            'reportConfidence': us(self.get_value_description('RC')),
+            'confidentialityRequirement': us(self.get_value_description('CR')),
+            'integrityRequirement': us(self.get_value_description('IR')),
+            'availabilityRequirement': us(self.get_value_description('AR')),
+            'modifiedAttackVector': us(self.get_value_description('MAV')),
+            'modifiedAttackComplexity': us(self.get_value_description('MAC')),
+            'modifiedPrivilegesRequired': us(self.get_value_description('MPR')),
+            'modifiedUserInteraction': us(self.get_value_description('MUI')),
+            'modifiedScope': us(self.get_value_description('MS')),
+            'modifiedConfidentialityImpact': us(self.get_value_description('MC')),
+            'modifiedIntegrityImpact': us(self.get_value_description('MI')),
+            'modifiedAvailabilityImpact': us(self.get_value_description('MA')),
+            # Scores
+            'baseScore': float(self.base_score),
+            'environmentalScore': float(self.environmental_score),
+            'temporalScore': float(self.temporal_score),
+            # Severities
+            'baseSeverity': us(base_severity),
+            'environmentalSeverity': us(temporal_severity),
+            'temporalSeverity': us(environmental_everity),
+        }

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     keywords='security cvss score calculator',
     packages=find_packages(),
     install_requires=dependencies,
+    tests_require=['jsonschema'],
     entry_points={
         'console_scripts': [
             'cvss_calculator = cvss.cvss_calculator:main',

--- a/tests/schemas/cvss-v2.0.json
+++ b/tests/schemas/cvss-v2.0.json
@@ -1,0 +1,104 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 2.0",
+    "id": "https://www.first.org/cvss/cvss-v2.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "accessVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL" ]
+        },
+        "accessComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "MEDIUM", "LOW" ]
+        },
+        "authenticationType": {
+            "type": "string",
+            "enum": [ "MULTIPLE", "SINGLE", "NONE" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "PARTIAL", "COMPLETE" ]
+        },
+        "exploitabilityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "reportConfidenceType": {
+            "type": "string",
+            "enum": [ "UNCONFIRMED", "UNCORROBORATED", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "collateralDamagePotentialType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "LOW_MEDIUM", "MEDIUM_HIGH", "HIGH", "NOT_DEFINED" ]
+        },
+        "targetDistributionType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "2.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+        },
+        "accessVector":                   { "$ref": "#/definitions/accessVectorType" },
+        "accessComplexity":               { "$ref": "#/definitions/accessComplexityType" },
+        "authentication":                 { "$ref": "#/definitions/authenticationType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "exploitability":                 { "$ref": "#/definitions/exploitabilityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/reportConfidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "collateralDamagePotential":      { "$ref": "#/definitions/collateralDamagePotentialType" },
+        "targetDistribution":             { "$ref": "#/definitions/targetDistributionType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" }
+    },
+    "required": [ "version", "vectorString", "baseScore" ]
+}

--- a/tests/schemas/cvss-v3.0.json
+++ b/tests/schemas/cvss-v3.0.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.0",
+    "id": "https://www.first.org/cvss/cvss-v3.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3.0/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/tests/schemas/cvss-v3.1.json
+++ b/tests/schemas/cvss-v3.1.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2019, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
+    "id": "https://www.first.org/cvss/cvss-v3.1.json?20190610",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.1" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3.1/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/tests/test_cvss2.py
+++ b/tests/test_cvss2.py
@@ -1,6 +1,7 @@
-from os import path
+import json
 import sys
 import unittest
+from os import path
 
 sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
 
@@ -243,6 +244,22 @@ class TestCVSS2(unittest.TestCase):
         e = [CVSS2(v)]
         i = 'Title: {0}\nThis is an overview of {0} problem.\nLinks: {0}'.format(v)
         self.assertEqual(parser.parse_cvss_from_text(i), e)
+
+    def test_json_schema_repr(self):
+        try:
+            import jsonschema
+        except ImportError:
+            return
+        with open(path.join(WD, 'vectors_random2')) as f:
+            for line in f:
+                vector, _ = line.split(' - ')
+                cvss = CVSS2(vector)
+                with open(path.join(WD, 'schemas/cvss-v2.0.json')) as schema_file:
+                    schema = json.load(schema_file)
+                try:
+                    jsonschema.validate(instance=cvss.as_json(), schema=schema)
+                except jsonschema.exceptions.ValidationError:
+                    self.fail('jsonschema validation failed on vector: {}'.format(vector))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change adds a method to both CVSS2 and CVSS3 objects to output data according to the official CVSS JSON schema. 

This allows the library to be used to format CVSS data in a standard
format, which is required for example in the CVE JSON schema:

https://github.com/CVEProject/cve-schema/blob/74f6baabe590adb17c274c9e8a3984fcbd63f421/schema/v5.0/CVE_JSON_5.0.schema#L868

or the CSAF schema:

https://github.com/oasis-tcs/csaf/blob/f042fc3b14b6ba1c59261da56eb76c02a0dd41fe/csaf_2.0/json_schema/csaf_json_schema.json#L1189

Tests are run against the list of random vectors and the JSON output is validated against the respective schema for each vector. The downside of this is that it takes a considerable amount of time, see e.g. timing in:

https://github.com/mprpic/cvss/actions/runs/757602131

Locally it's a bit faster but still takes about 5-10 mins depending on the hardware.