### PR TITLE
Official CVSS 3.1 schema was updated to fix a regex bug

### DIFF
--- a/tests/schemas/cvss-v3.1.json
+++ b/tests/schemas/cvss-v3.1.json
@@ -1,6 +1,6 @@
 {
     "license": [
-        "Copyright (c) 2019, FIRST.ORG, INC.",
+        "Copyright (c) 2021, FIRST.ORG, INC.",
         "All rights reserved.",
         "",
         "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
@@ -23,7 +23,7 @@
 
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
-    "id": "https://www.first.org/cvss/cvss-v3.1.json?20190610",
+    "id": "https://www.first.org/cvss/cvss-v3.1.json?20210501",
     "type": "object",
     "definitions": {
         "attackVectorType": {
@@ -108,7 +108,7 @@
         },
         "vectorString": {
             "type": "string",
-            "pattern": "^CVSS:3.1/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+            "pattern": "^CVSS:3.1/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
         },
         "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
         "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },


### PR DESCRIPTION
This bug was reported here:

https://github.com/CVEProject/cve-schema/issues/57

And the regex was fixed to remove the redundant "U" character.