### PR TITLE
Add kwarg to sort CVSS JSON dict before returning it

### DIFF
--- a/cvss/cvss2.py
+++ b/cvss/cvss2.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 from decimal import Decimal as D, ROUND_HALF_UP
 
 from .constants2 import METRICS_ABBREVIATIONS, METRICS_MANDATORY, METRICS_VALUES, \
-    METRICS_VALUE_NAMES
+    METRICS_VALUE_NAMES, OrderedDict
 from .exceptions import CVSS2MalformedError, CVSS2MandatoryError, CVSS2RHMalformedError, \
     CVSS2RHScoreDoesNotMatch
 
@@ -306,7 +306,7 @@ class CVSS2(object):
 
         json.dumps(cvss2.as_json())
 
-        Or get sorted JSON with:
+        Or get sorted JSON in an OrderedDict with:
 
         json.dumps(cvss2.as_json(sort=True))
 
@@ -345,6 +345,6 @@ class CVSS2(object):
         if self.environmental_score:
             data['environmentalScore'] = float(self.environmental_score)
         if sort:
-            data = {key: value for key, value in sorted(data.items())}
+            data = OrderedDict(sorted(data.items()))
 
         return data

--- a/cvss/cvss2.py
+++ b/cvss/cvss2.py
@@ -295,7 +295,7 @@ class CVSS2(object):
     def __hash__(self):
         return hash(self.clean_vector())
 
-    def as_json(self):
+    def as_json(self, sort=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official
         CVSS JSON schema:
@@ -305,6 +305,10 @@ class CVSS2(object):
         Serialize a CVSS2 instance to JSON with:
 
         json.dumps(cvss2.as_json())
+
+        Or get sorted JSON with:
+
+        json.dumps(cvss2.as_json(sort=True))
 
         Returns:
             (dict): JSON schema-compatible CVSS representation
@@ -340,5 +344,7 @@ class CVSS2(object):
             data['temporalScore'] = float(self.temporal_score)
         if self.environmental_score:
             data['environmentalScore'] = float(self.environmental_score)
+        if sort:
+            data = {key: value for key, value in sorted(data.items())}
 
         return data

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -15,7 +15,7 @@ import copy
 from decimal import Decimal as D, ROUND_CEILING
 
 from .constants3 import METRICS_ABBREVIATIONS, METRICS_MANDATORY, METRICS_VALUES, \
-    METRICS_VALUE_NAMES
+    METRICS_VALUE_NAMES, OrderedDict
 from .exceptions import CVSS3MalformedError, CVSS3MandatoryError, CVSS3RHMalformedError, \
     CVSS3RHScoreDoesNotMatch
 
@@ -421,7 +421,7 @@ class CVSS3(object):
 
         json.dumps(cvss.as_json())
 
-        Or get sorted JSON with:
+        Or get sorted JSON in an OrderedDict with:
 
         json.dumps(cvss.as_json(sort=True))
 
@@ -474,7 +474,7 @@ class CVSS3(object):
             'environmentalSeverity': us(temporal_severity),
             'temporalSeverity': us(environmental_everity),
         }
-        
+
         if sort:
-            data = {key: value for key, value in sorted(data.items())}
+            data = OrderedDict(sorted(data.items()))
         return data

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -409,7 +409,7 @@ class CVSS3(object):
     def __hash__(self):
         return hash(self.clean_vector())
 
-    def as_json(self):
+    def as_json(self, sort=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official
         CVSS JSON schema:
@@ -420,6 +420,10 @@ class CVSS3(object):
         Serialize a `cvss` instance to JSON with:
 
         json.dumps(cvss.as_json())
+
+        Or get sorted JSON with:
+
+        json.dumps(cvss.as_json(sort=True))
 
         Returns:
             (dict): JSON schema-compatible CVSS representation
@@ -433,7 +437,7 @@ class CVSS3(object):
             return text.upper().replace('-', '_').replace(' ', '_')
 
         base_severity, temporal_severity, environmental_everity = self.severities()
-        return {
+        data = {
             # Meta
             'version': '3.' + str(self.minor_version),
             # Vector
@@ -470,3 +474,7 @@ class CVSS3(object):
             'environmentalSeverity': us(temporal_severity),
             'temporalSeverity': us(environmental_everity),
         }
+        
+        if sort:
+            data = {key: value for key, value in sorted(data.items())}
+        return data

--- a/tests/test_cvss2.py
+++ b/tests/test_cvss2.py
@@ -245,6 +245,17 @@ class TestCVSS2(unittest.TestCase):
         i = 'Title: {0}\nThis is an overview of {0} problem.\nLinks: {0}'.format(v)
         self.assertEqual(parser.parse_cvss_from_text(i), e)
 
+    def test_json_ordering(self):
+        with open(path.join(WD, 'vectors_random2')) as f:
+            for line in f:
+                vector, _ = line.split(' - ')
+                cvss = CVSS2(vector).as_json(sort=True)
+                old_key = ''
+                for key in cvss:
+                    if key < old_key:
+                        self.fail('dict ordering was not preserved: key {} less than previous key {} for CVSS object {}'.format(key, old_key, cvss))
+                    old_key = key
+
     def test_json_schema_repr(self):
         try:
             import jsonschema

--- a/tests/test_cvss3.py
+++ b/tests/test_cvss3.py
@@ -317,6 +317,22 @@ class TestCVSS3(unittest.TestCase):
         i = 'Title: {0}\nThis is an overview of {0} problem.\nLinks: {0}'.format(v)
         self.assertEqual(parser.parse_cvss_from_text(i), e)
 
+    def test_json_ordering(self):
+        vectors_to_schema = {
+            'vectors_random3': 'schemas/cvss-v3.0.json',
+            'vectors_random31': 'schemas/cvss-v3.1.json',
+        }
+        for vectors_file_path, schema_file_path in vectors_to_schema.items():
+            with open(path.join(WD, vectors_file_path)) as f:
+                for line in f:
+                    vector, _ = line.split(' - ')
+                    cvss = CVSS3(vector).as_json(sort=True)
+                    old_key = ''
+                    for key in cvss:
+                        if key < old_key:
+                            self.fail('dict ordering was not preserved: key {} less than previous key {} for CVSS object {}'.format(key, old_key, cvss))
+                        old_key = key
+
     def test_json_schema_repr(self):
         try:
             import jsonschema


### PR DESCRIPTION
In some cases you can use json.dumps(my_dict, sort_keys=True), but this PR will support cases where the Python dict should be sorted while remaining a Python dict (so is not dumped to JSON format).